### PR TITLE
Add PATCH_NOTES.md for v0.1 Release and Move Patch Notes Out of README

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -1,0 +1,30 @@
+# Patch Notes
+
+## v0.1
+
+### Features
+- User Authentication: Secure registration and login using JWT
+- Task Management: Create, view, update, and delete maintenance tasks
+- Task Status Tracking: Set and update status (Pending, In-Progress, Done) for each task. Filter and report by status in the UI and API
+- Categories/Tags: Assign tasks to categories such as plumbing, electrical, and more. Category dropdown now shows a single "All" option for clarity
+- Database Security: Persistent storage using SQLite and TypeORM, with parameterized queries to prevent SQL injection
+
+### Improvements
+- Codebase Cleanup: All major files refactored for readability, maintainability, and consistent code style. Unused code and dependencies removed
+- UI/UX Improvements: Modern, responsive interface with clear filtering, pagination, and feedback via toast notifications
+- Fixed category dropdown to show only a single "All" option
+- Improved comments and docstrings throughout codebase
+- Ensured consistent code style and formatting
+
+### Developer Notes
+- Refactored all major files for clarity and maintainability
+- Removed unused code and dependencies
+- Improved comments and docstrings throughout codebase
+- Ensured consistent code style and formatting
+
+### Setup & Deployment
+- See README.md for setup, environment variables, and deployment instructions
+
+---
+
+For previous changes and details, see the README.md and commit history.


### PR DESCRIPTION
This PR introduces a dedicated PATCH_NOTES.md file to document all major features, improvements, and developer notes for the v0.1 release.

- Patch notes and version history are now separated from the main README for clarity and maintainability.
- README is focused on setup, usage, and project overview.
- PATCH_NOTES.md includes details on authentication, CRUD tasks, categories/tags, codebase cleanup, UI/UX improvements, and developer notes for v0.1.

This update improves project documentation and organization, making it easier to track changes and future releases.